### PR TITLE
Fix info logging check

### DIFF
--- a/Log.swift
+++ b/Log.swift
@@ -36,7 +36,7 @@ struct Log {
         print("🐛 [DEBUG] \(message)")
     }
     static func info(_ message: Any) {
-        guard logLevel <= LogLevel.debug else { return }
+        guard logLevel <= LogLevel.info else { return }
         print("🗣 [INFO] \(message)")
     }
     static func warn(_ message: Any) {


### PR DESCRIPTION
This fixes a bug where setting `logLevel = .info` fails to print out info level logs