### PR TITLE
Refactored to add custom prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,36 +3,40 @@ A custom Logger that uses emojis to represent log levels
 
 ### Usage
 
+    📋("This is a trace level message")   
     🐛("This is a debug level message")   
     🗣("This is an info level message")   
     💥("This is a warn level message")
     💩("This is an error level message")
 
->🐛 [DEBUG] This is a debug level message  
+>📋 [TRACE] This is a trace level message
+🐛 [DEBUG] This is a debug level message  
 🗣 [INFO]  This is an info level message  
 💥 [WARN]  This is a warn level message  
 💩 [ERROR] This is an error level message  
 
-You can easily find these emojis by hitting `ctrl+cmd+space`. Once you use these they will be at the top of your list automatically. To find them the first time, hit `ctrl+cmd+space` and type "bug" to find "🐛", type "speak" to find "🗣", type "crash" to find "💥", and type "poop" to find "💩". I know what you're thinking... Why use the "crash" emoji for warn? Because the poop emoji is funnier. As in "Ahh shit! an error!"
+You can easily find these emojis by hitting `ctrl+cmd+space`. Once you use these they will be at the top of your list automatically. To find them the first time, hit `ctrl+cmd+space` and type "clipboard" to find 📋, "bug" to find "🐛", type "speak" to find "🗣", type "crash" to find "💥", and type "poop" to find "💩". I know what you're thinking... Why use the "crash" emoji for warn? Because the poop emoji is funnier. As in "Ahh shit! an error!"
 
-You can also use:
+You can also add your own prefixes like this:
 
-    Log.debug("This is a debug level message")
-    Log.info("This is an info level message")
-    Log.warn("This is a warn level message")
-    Log.error("This is an error level message ")
+    📋("This is a trace level message", self, #function)   
+    🐛("This is a debug level message", self, #function)   
+    🗣("This is an info level message", self, #function)   
+    💥("This is a warn level message", self, #function)
+    💩("This is an error level message", self, #function)
 
->🐛 [DEBUG] This is a debug level message  
-🗣 [INFO]  This is an info level message  
-💥 [WARN]  This is a warn level message  
-💩 [ERROR] This is an error level message  
+>📋 [TRACE] [MyClass] [someFunction()] This is a trace level message
+🐛 [DEBUG] [MyClass] [someFunction()] This is a debug level message  
+🗣 [INFO]  [MyClass] [someFunction()] This is an info level message  
+💥 [WARN]  [MyClass] [someFunction()] This is a warn level message  
+💩 [ERROR] [MyClass] [someFunction()] This is an error level message  
 
 ### Customization
 
 You can easily make custom logging functions which makes your logging more expressive and allows you to easily filter your logs for your own debugging purposes.
 
-    func 🏅(_ message: Any) {
-      Log.custom(level: .info, prefix: "🏅 [SUCCESS]", message: message)
+    func 🏅(_ message: Any, _ prefixes: Any...) {
+        Log.custom(rank: Log.info.rank, prefix: "🏅 [SUCCESS]").output(message, prefixedBy: prefixes)
     }
 
 Which you would then use like this
@@ -44,9 +48,11 @@ Which you would then use like this
 Or if you're trying to figure some things out by adding `print` messages everywhere, you can add a log message that allows you to easily filter for the things you're looking for. Just don't commit this 😉.
 
     func 🤔(_ message: Any) {
-      Log.custom(level: .debug, prefix: "🤔 [STEVE]", message: message)
+      Log.custom(rank: Log.debug.rank, prefix: "🤔 [STEVE]").output(message, prefixedBy: prefixes)
     }
 
     🤔("This is a custom message for Steve. He's trying to figure something out and promises not to commit this line 😊")
 
 >🤔 [STEVE] This is a custom message for Steve. He's trying to figure something out and promises not to commit this line 😊
+
+You can easily find these messages in the console by searching "[STEVE]"


### PR DESCRIPTION
# What

This is a major refactoring of the internals of `EmojiLogger`. 

* add the ability to add custom prefixes to log messages
    `🐛("my message", self)` 
     would output:
    >🐛[DEBUG] [MyClass] my message
* unifies the underlying logic through a single function.
    * removes duplication of logic and risk of differentiation between methods
* removes static functions like `Log.debug("my message")`
    * refactoring everything into the enum removed this possibility. These methods could be rebuilt by renaming the enum or by adding static functions like `debug` or `logDebug`
* add `Loggable` protocol
    * this strips the module name when using `self` as a prefix
* add documentation

# Why

I found myself doing things like this a lot 

    🐛("[\(type(of: self))] [\(#function)] here's a thing: \(thing)")

This is messy and can be cleaned up like this now

    🐛("here's a thing: \(thing)", self, #function)

It puts the important information up front which makes it easier to read and understand. 

